### PR TITLE
Fix: handle gyms without name + add additonal configurations

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -22,11 +22,17 @@ language = "en"
 max_gymname_len = 27
 # raidtime string format (see https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes)
 time_format = "%H:%M"
+# string to use, if there is no gymname set in database (NULL, None)
+unknown_gym_name = "N/A"
 
 [templates]
 # General:
 #  - Use keyword with ${keyword}
 #  - available keyword can be find for every tmpl string in description
+
+# message to display, if message was cut because of maximum Telegram message length reached
+# Available keywords: -
+tmpl_msglimit_reached_msg = "\n...msg too long"
 
 # message to display, if there are no raids available.
 # Available keywords: -

--- a/simpletelegramapi.py
+++ b/simpletelegramapi.py
@@ -20,7 +20,6 @@ import logging
 '''
 log = logging.getLogger(__name__)
 MAX_MSG_LEN = 3000
-TRIMMED_END_STR = '..'
 
 '''
 ****************************************
@@ -40,16 +39,16 @@ class SimpleTelegramApi:
         decoded_response = response.content.decode("utf8")
         return decoded_response
 
-    def _util_limit_msg_len(self, text:str, smart_trim:bool = True, trim_str:str="\n") -> str:
+    def _util_limit_msg_len(self, text:str, smart_trim:bool = True, trim_end_str:str="...", trim_str:str="\n") -> str:
         if len(text) > MAX_MSG_LEN:
-            # trim to max len - TRIMMED_END_STR
-            trimmed_text = text[:(MAX_MSG_LEN-len(TRIMMED_END_STR))]
+            # trim to max len - trim_end_str
+            trimmed_text = text[:(MAX_MSG_LEN-len(trim_end_str))]
             if smart_trim:
                 # trim to last found trim_str
                 index = trimmed_text.rfind(trim_str)
                 trimmed_text = trimmed_text[:index]
-            # mark trimmed message with TRIMMED_END_STR substring
-            trimmed_text += TRIMMED_END_STR
+            # mark trimmed message with trim_end_str substring
+            trimmed_text += trim_end_str
         else:
             trimmed_text = text
         return trimmed_text
@@ -72,9 +71,9 @@ class SimpleTelegramApi:
             result = False
         return result
 
-    def send_message(self, chat_id:int, text:str, smart_trim:bool = True, parse_mode="HTML"):
+    def send_message(self, chat_id:int, text:str, smart_trim:bool = True, trim_end_str:str="...", parse_mode="HTML"):
         try:
-            text = urllib.parse.quote_plus(self._util_limit_msg_len(text, smart_trim))
+            text = urllib.parse.quote_plus(self._util_limit_msg_len(text, smart_trim, trim_end_str))
             response = self._send_request("sendMessage?text={}&chat_id={}&parse_mode={}".format(text, chat_id, parse_mode))
             response = json.loads(response)
             if not response["ok"]:
@@ -86,9 +85,9 @@ class SimpleTelegramApi:
             response = None
         return response
 
-    def edit_message(self, chat_id:int, message_id:int, text:str, smart_trim:bool = True, parse_mode="HTML"):
+    def edit_message(self, chat_id:int, message_id:int, text:str, smart_trim:bool = True, trim_end_str:str="...", parse_mode="HTML"):
         try:
-            text = urllib.parse.quote_plus(self._util_limit_msg_len(text, smart_trim))
+            text = urllib.parse.quote_plus(self._util_limit_msg_len(text, smart_trim, trim_end_str))
             response = self._send_request("editMessageText?chat_id={}&message_id={}&parse_mode={}&text={}".format(chat_id, message_id, parse_mode, text))
             response = json.loads(response)
             if not response["ok"]:


### PR DESCRIPTION
1. Unknown gym names will know be handled and don't generate errors
2. new configuration parameter (see updated config.toml.example):
- (optional) [format] `unknown_gym_name`: this string will be used, if gym name is unknown. Fallback if not set: "N/A"
- (optional) [templates] `tmpl_msglimit_reached_msg`: this string will be added at the end of the message, if Telegram message limit is reached. Fallback if not set: "..."