### PR TITLE
New features: configurate pin message and time order

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,18 @@
 tg_raidbot is a configurable Telegram raid summary bot for scanner systems like RDM and MAD (currently only RDM is supported).
 
 # Features
-- Configurable raid summary message templates with some keywords (see '[templates]' chapter in `config.toml.example`)
-- Configurable time format
-- Automaticly pinning raid summary message
-- Multiple languages supported: de, en, es, fr, hi, id, it, ja, ko, pl, pt-br, ru, sv, th, tr, zh-tw
-- Multiple raid chats, each configurable:
-  - Choose between raid level grouped raid summary message or only time sorted for each raid chat
+- Configurable message templates with some keywords (see '[templates]' chapter in `config.toml.example`)
+- Configurable time format for raid start / end times
+- Multiple languages supported for raidnames, pokemon names and attacks: de, en, es, fr, hi, id, it, ja, ko, pl, pt-br, ru, sv, th, tr, zh-tw
+- Multiple raid chats, each with following individual configuration:
+  - choose, if raids are grouped by raid level or only ordered by time
+  - choose time order (latest or earliest end time first)
   - geofence support
   - include or exclude raid eggs
+  - automatically pin message (activate or deactivate)
 
 # Limitations
-Only RDM is supported for now. Extension to support additional scanner system should be easy by extending `scannerconnector.py`. PRs welcome.
+Only RDM is supported for now. Extension to support additional scanner systems should be easy by extending `scannerconnector.py`. PRs welcome.
 
 # Installation
 It is highly recommended to use virtual python environment (example here with virtualenv plugin).
@@ -43,6 +44,34 @@ Based on the examples in [Installation](#Installation) you can use following eco
 ## config.toml options
 For now, see `config.toml.example` file. All options are described there.
 
+### example 1
+- public channel: @blub
+- show raids level 5 and 6 (mega) including raid eggs grouped by raid level. First level 5, second level 6
+- raids with earliest end time should be showed first
+- no geofence filtering (all raids in database). Remark: by don't provide geofence parameter
+
+```
+[[raidconfig]]
+chat_id = "@blub"
+raidlevel = [5,6]
+eggs = true
+raidlevel_grouping = true
+order_time_reverse = false
+```
+### example 2
+- private group chat_id: -987654321
+- show only already started raids level 1, 2 and 3 not grouped by raid level, only by time
+- raids with latest end time should be showed first
+- only raids in rectangular geofence between lat:40.0 lon:7.0 and lat:50.0 lon:8.0
+
+```
+[[raidconfig]]
+chat_id = "-987654321"
+raidlevel = [3,2,1] # remark: order will have no effect, because of 'raidlevel_grouping = false'
+eggs = false
+raidlevel_grouping = false
+order_time_reverse = true
+geofence = "40.0 7.0, 40.0 8.0, 50.0 8.0, 50.0 7.0, 40.0 7.0"
+```
 # Credits
 [WatWowMap/pogo-translations](https://github.com/WatWowMap/pogo-translations), where the pogo translation data are fetched from.
-

--- a/config.toml.example
+++ b/config.toml.example
@@ -22,7 +22,7 @@ language = "en"
 max_gymname_len = 27
 # raidtime string format (see https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes)
 time_format = "%H:%M"
-# string to use, if there is no gymname set in database (NULL, None)
+# string to use, if there is no gymname set in database (NULL, None). Default: "N/A"
 unknown_gym_name = "N/A"
 
 [templates]
@@ -54,15 +54,19 @@ tmpl_raid_msg = "🐣${pokemon_name} ${time_start}-${time_end}\n└⚔️${atk_f
 # add a separate [[raidconfig]] block for every raid channel/group
 ##################################################################
 [[raidconfig]]
-chat_id = "123456789"
-raidlevel = [5,6]
-eggs = true
-raidlevel_grouping = true
-geofence = "40.0 7.0, 40.0 8.0, 50.0 8.0, 50.0 7.0, 40.0 7.0"
+chat_id = "123456789"       # @channelname or chat_id number
+raidlevel = [5,6]           # comma seperated raid levels (1-10) to be showed. Order in the raid message is the same as configurated.
+eggs = true                 # (optional) true[default]: also show raid eggs, false: show only already started raids
+raidlevel_grouping = true   # (optional) true[default]: order raids by raidlevel + time, false: order raids only by time
+order_time_reverse = false  # (optional) true: order raids by raidlevel + time, false[default]: order raids only by time
+pin_msg = true              # (optional) true[default]: always pin new raid message, false: don't pin raid message (if you change this, you need to delete old message first)
+geofence = "40.0 7.0, 40.0 8.0, 50.0 8.0, 50.0 7.0, 40.0 7.0" # (optional): filter raids by geofence. Must be a closed geofence (last coordinate = first coordinate). Format: "lat_1 lon_1, lat_2 lon_2, ..., lat_1 lon_1"
 
+# additional raidchannel(s) -> remove '#' and set values.
 #[[raidconfig]]
-#chat_id = "-987654321"
-#raidlevel = [1]
-#eggs = false
-#raidlevel_grouping = false
-
+#chat_id =
+#raidlevel =
+#eggs =
+#raidlevel_grouping =
+#order_time_reverse =
+#geofence =


### PR DESCRIPTION
New `[[raidconfig]]` options:
- `order_time_reverse`: (optional) true: order raids by raidlevel + time, false[default]: order raids only by tim
- `pin_msg`: (optional) true[default]: always pin new raid message, false: don't pin raid message (if you change this, you need to delete old message first)

Existing `[[raidconfig]]` options now optional:
- `eggs`: true[default]
- `raidlevel_grouping`: true[default]

Extend documentation and added examples in README.
