### PR TITLE
Add Telegram topics support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ tg_raidbot is a configurable Telegram raid summary bot for scanner systems like 
 - Configurable message templates with some keywords (see '[templates]' chapter in `config.toml.example`)
 - Configurable time format for raid start / end times
 - Multiple languages supported for raidnames, pokemon names and attacks: de, en, es, fr, hi, id, it, ja, ko, pl, pt-br, ru, sv, th, tr, zh-tw
+- Chat topics support (see [Telegram-Blog](https://www.telegram.org/blog/topics-in-groups-collectible-usernames))
+  - Remark: you need to enable thsi feature first in group setting -> enable 'Topics' switch
 - Multiple raid chats, each with following individual configuration:
   - choose, if raids are grouped by raid level or only ordered by time
   - choose time order (latest or earliest end time first)
@@ -73,5 +75,6 @@ raidlevel_grouping = false
 order_time_reverse = true
 geofence = "40.0 7.0, 40.0 8.0, 50.0 8.0, 50.0 7.0, 40.0 7.0"
 ```
+
 # Credits
 [WatWowMap/pogo-translations](https://github.com/WatWowMap/pogo-translations), where the pogo translation data are fetched from.

--- a/config.toml.example
+++ b/config.toml.example
@@ -55,6 +55,7 @@ tmpl_raid_msg = "🐣${pokemon_name} ${time_start}-${time_end}\n└⚔️${atk_f
 ##################################################################
 [[raidconfig]]
 chat_id = "123456789"       # @channelname or chat_id number
+message_thread_id = 123     # (optional) message_thread_id number of a chat topic. Needed in addition to 'chat_id', if you would like to post the message in a chat topic
 raidlevel = [5,6]           # comma seperated raid levels (1-10) to be showed. Order in the raid message is the same as configurated.
 eggs = true                 # (optional) true[default]: also show raid eggs, false: show only already started raids
 raidlevel_grouping = true   # (optional) true[default]: order raids by raidlevel + time, false: order raids only by time

--- a/msgidcache.py
+++ b/msgidcache.py
@@ -1,0 +1,77 @@
+#!/usr/local/bin/python
+# -*- coding: utf-8 -*-
+
+'''
+****************************************
+* Import
+****************************************
+'''
+# os functions (path, ...)
+import os
+import sys
+# .ini config parser and datacache
+import json
+# logging
+import logging
+
+'''
+****************************************
+* Global variables
+****************************************
+'''
+log = logging.getLogger(__name__)
+
+'''
+****************************************
+* Classes
+****************************************
+'''
+class MsgIdCache():
+    def __init__(self, filename:str=".msgid_cache"):
+        self._filename = filename
+        self._msgid_cache_dict = {}
+        pass
+
+    def _create_key_string(self, chat_id:str, message_thread_id:int=None) -> str:
+        if message_thread_id is None:
+            key = f"{chat_id}"
+        else:
+            key = f"{chat_id}:{message_thread_id}"
+        return key
+
+    def restore_cache(self) -> None:
+        try:
+            f = open(self._filename, "r")
+            msgid_cache_file = json.load(f)
+            f.close()
+            self._msgid_cache_dict = msgid_cache_file
+            log.info(f"load .msgid_cache: {self._msgid_cache_dict}")
+        except Exception as e:
+            log.warning(f"can't load .msgid_cache. exception:{e}")
+
+    def store_cache(self) -> None:
+        try:
+            f = open(self._filename, "w")
+            json.dump(self._msgid_cache_dict, f)
+            log.debug(f"save .msgid_cache: {self._msgid_cache_dict}")
+            f.close()
+        except Exception as e:
+            log.warning(f"Exception '{type(e)}' in _save_msgid_cache_dict()")
+
+    def set_message_id(self, chat_id:str, message_thread_id:int, message_id:int) -> None:
+        try:
+            key = self._create_key_string(chat_id, message_thread_id)
+            self._msgid_cache_dict.update({key: message_id})
+        except Exception:
+            log.exception(f"set_message_id() exception")
+
+    def get_message_id(self, chat_id:str, message_thread_id:int=None) -> int:
+        message_id = None
+        try:
+            key = self._create_key_string(chat_id, message_thread_id)
+            if key in self._msgid_cache_dict.keys():
+                message_id = self._msgid_cache_dict[key]
+        except Exception:
+            log.exception(f"get_message_id() exception")
+        return message_id
+

--- a/run.py
+++ b/run.py
@@ -56,7 +56,7 @@ def config_logging(logger, console_loglevel = logging.INFO, file_loglevel = None
     # file logging
     if file_loglevel is not None:
         formatter_file = logging.Formatter('[%(asctime)s] [%(name)12s] [%(levelname)7s] %(message)s')
-        file_handler = RotatingFileHandler('RDMStatusTGBot.log', maxBytes=10**5, backupCount=5)
+        file_handler = RotatingFileHandler('tg_raidbot.log', maxBytes=10000000, backupCount=5)
         file_handler.setLevel(file_loglevel)
         file_handler.setFormatter(formatter_file)
         logger.addHandler(file_handler)

--- a/scannerconnector.py
+++ b/scannerconnector.py
@@ -38,12 +38,13 @@ class DbConnector():
         self._password = password
 
     def __del__(self):
+        log.debug("DbConnector: __del__")
         self._disconnect()
 
     def _connect(self):
         try:
-            # only create new connection, if not already a connection was created before
-            if self._db_connection is None:
+            # only create new connection, if not already a connection is available
+            if self._db_connection is None or not self._db_connection.is_connected():
                 self._db_connection = mysql.connector.connect(
                     host = self._host,
                     port = self._port,
@@ -59,8 +60,8 @@ class DbConnector():
 
     def _disconnect(self):
         if self._db_connection is not None:
+            log.debug("DbConnector: disconnect")
             self._db_connection.close()
-            self._db_connection = None
 
     def execute_query(self, query, commit=False, disconnect=True):
         result = None
@@ -75,6 +76,7 @@ class DbConnector():
                 result = cursor.fetchall()
             if disconnect:
                 self._disconnect()
+            cursor.close()
             log.debug(f"DbConnector: SQL query successfully executed")
             log.debug(f"DbConnector: SQL query result: {result}")
         except Error as e:


### PR DESCRIPTION
Telegram is supporting topics in supergroups. This PR provides support for this feature. You can add `message_thread_id` now in addition to `chat_id` to post a raid message in a topic of of supergroup. See [Telegram-Blog](https://www.telegram.org/blog/topics-in-groups-collectible-usernames)

New `[[raidconfig]]` parameter:
- `message_thread_id`: (optional) message_thread_id number of a chat topic. Needed in addition to `chat_id`, if you would like to post the message in a chat topic.